### PR TITLE
Put traits default points to 5.

### DIFF
--- a/Resources/ConfigPresets/Ronstation/RonStation.toml
+++ b/Resources/ConfigPresets/Ronstation/RonStation.toml
@@ -19,6 +19,7 @@ station_goals      = false
 map_pool           = "RonstationMapPool"
 auto_eat_food      = true
 auto_eat_drinks    = true
+traits_default_points = 0
 
 [hub]
 tags = "lang:en-US,region:am_n_e,rp:low"

--- a/Resources/ConfigPresets/Ronstation/RonStation.toml
+++ b/Resources/ConfigPresets/Ronstation/RonStation.toml
@@ -19,7 +19,7 @@ station_goals      = false
 map_pool           = "RonstationMapPool"
 auto_eat_food      = true
 auto_eat_drinks    = true
-traits_default_points = 0
+traits_default_points = 5
 
 [hub]
 tags = "lang:en-US,region:am_n_e,rp:low"


### PR DESCRIPTION
# Description

Places default trait points to 5, so you have to have a bit more negative traits first before going for positive traits.

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

:cl:
- tweak: Placed trait numbers to 5 for balance reasons.
